### PR TITLE
Fix getSLEB128 (was often returning -1)

### DIFF
--- a/dwarf-el.cabal
+++ b/dwarf-el.cabal
@@ -8,7 +8,6 @@ Copyright:     Eyal Lotem, Erik Charlebois
 Maintainer:    Eyal Lotem <eyal.lotem@gmail.com>
 Stability:     unstable
 Cabal-Version: >= 1.6
-Build-Depends: base
 Build-Type:    Simple
 Synopsis:      Parser for DWARF debug format.
 Description:   Parser for DWARF debug format.
@@ -16,7 +15,7 @@ Description:   Parser for DWARF debug format.
 library
     build-depends:   base >= 2 && < 5, transformers >= 0.3,
                      bytestring, containers, binary,
-                     utf8-string >= 0.3.7
+                     utf8-string >= 0.3.7, monad-loops >= 0.3
     hs-source-dirs:  src
     exposed-modules: Data.Dwarf
     other-modules:   Data.Dwarf.Types,

--- a/src/Data/Dwarf/Utils.hs
+++ b/src/Data/Dwarf/Utils.hs
@@ -59,8 +59,8 @@ getSLEB128 =
         if testBit byte 7 then
             go temp (shift + 7)
          else
-            if shift < 32  && testBit byte 6 then
-                pure $ fromIntegral $ temp .|. ((-1) `shiftL` shift)
+            if testBit byte 6 then
+                pure $ fromIntegral $ temp .|. ((-1) `shiftL` (shift + 7))
              else
                 pure $ fromIntegral temp
     in go 0 0


### PR DESCRIPTION
Hi,
This pull request fixes decoding of signed variable length numbers.

Best,
Sylvain
