### PR TITLE
Various updates

### DIFF
--- a/dwarf-el.cabal
+++ b/dwarf-el.cabal
@@ -14,7 +14,7 @@ Description:   Parser for DWARF debug format.
 
 library
     build-depends:   base >= 2 && < 5, transformers >= 0.3,
-                     bytestring, containers, binary, text, text-show
+                     bytestring, containers, binary, text
     hs-source-dirs:  src
     exposed-modules: Data.Dwarf
     other-modules:   Data.Dwarf.Types,

--- a/dwarf-el.cabal
+++ b/dwarf-el.cabal
@@ -1,5 +1,5 @@
 Name:          dwarf-el
-Version:       0.3
+Version:       0.4
 License:       BSD3
 License-file:  LICENSE
 Category:      Data

--- a/src/Data/Dwarf.hs
+++ b/src/Data/Dwarf.hs
@@ -36,7 +36,6 @@ module Data.Dwarf
   , DW_DSC(..), dw_dsc
   ) where
 
-import           Control.Applicative (Applicative(..), (<$>), (<$))
 import           Control.Arrow ((&&&), (***))
 import           Control.Monad ((<=<))
 import           Control.Monad.Trans.Class (lift)
@@ -61,8 +60,6 @@ import qualified Data.Map as M
 import           Data.Maybe (listToMaybe)
 import           Data.String (IsString(..))
 import           Data.Text (Text)
-import qualified Data.Text as Text
-import           Data.Traversable (traverse)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Numeric (showHex)

--- a/src/Data/Dwarf.hs
+++ b/src/Data/Dwarf.hs
@@ -63,13 +63,10 @@ import           Data.Text (Text)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           Numeric (showHex)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 newtype CUOffset = CUOffset Word64
   deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow CUOffset where showbPrec = genericShowbPrec
 
 -- Don't export a constructor, so users can only read DieID's, not
 -- create fake ones, which is slightly safer.
@@ -98,7 +95,6 @@ data CUContext = CUContext
 newtype AbbrevId = AbbrevId Word64
   deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow AbbrevId where showbPrec = genericShowbPrec
 
 data DW_ABBREV = DW_ABBREV
     { abbrevId        :: AbbrevId
@@ -191,7 +187,6 @@ data Range = Range
   , rangeEnd :: !Word64
   } deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow Range where showbPrec = genericShowbPrec
 
 -- Section 7.20 - Address Range Table
 -- Returns the ranges that belong to a CU
@@ -229,7 +224,6 @@ data DW_MACINFO
     | DW_MACINFO_vendor_ext Word64 Text   -- ^ Implementation defined
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_MACINFO where showbPrec = genericShowbPrec
 
 -- | Retrieves the macro information for a compilation unit from a given substring of the .debug_macinfo section. The offset
 -- into the .debug_macinfo section is obtained from the DW_AT_macro_info attribute of a compilation unit DIE.
@@ -264,7 +258,6 @@ data DW_CIEFDE
         }
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_CIEFDE where showbPrec = genericShowbPrec
 
 getCIEFDE :: Endianess -> TargetSize -> Get DW_CIEFDE
 getCIEFDE endianess target64 = do
@@ -359,13 +352,12 @@ data DIE = DIE
     , dieChildren   :: [DIE]
     , dieReader     :: Reader         -- ^ Decoder used to decode this entry. May be needed to further parse attribute values.
     }
-instance Show DIE where show = Text.unpack . showt
-instance TextShow DIE where
-    showb (DIE (DieID i) tag attrs children _) =
+instance Show DIE where
+    show (DIE (DieID i) tag attrs children _) =
         mconcat $ mconcat
-        [ [ "DIE@", fromString (showHex i ""), "{", showb tag, " (", showb (length children), " children)"]
+        [ [ "DIE@", fromString (showHex i ""), "{", show tag, " (", show (length children), " children)"]
         , mconcat
-          [ [" ", showb attr, "=(", showb val, ")"]
+          [ [" ", show attr, "=(", show val, ")"]
           | (attr, val) <- attrs
           ]
         , [ "}" ]

--- a/src/Data/Dwarf/AT.hs
+++ b/src/Data/Dwarf/AT.hs
@@ -7,8 +7,6 @@ import           Data.Int (Int64)
 import           Data.Text (Text)
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 data DW_ATVAL
     = DW_ATVAL_INT    Int64
@@ -19,7 +17,6 @@ data DW_ATVAL
     | DW_ATVAL_BOOL   Bool
     deriving (Eq, Ord, Show, Generic)
 
-instance TextShow DW_ATVAL where showbPrec = genericShowbPrec
 
 data DW_AT
     = DW_AT_sibling              -- ^ reference
@@ -148,7 +145,6 @@ data DW_AT
     | DW_AT_user Word64          -- ^ user extension
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_AT where showbPrec = genericShowbPrec
 
 dw_at :: Word64 -> DW_AT
 dw_at 0x01 = DW_AT_sibling

--- a/src/Data/Dwarf/ATE.hs
+++ b/src/Data/Dwarf/ATE.hs
@@ -3,8 +3,6 @@ module Data.Dwarf.ATE where
 
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import TextShow (TextShow(..))
-import TextShow.Generic (genericShowbPrec)
 
 data DW_ATE
     = DW_ATE_address
@@ -24,7 +22,6 @@ data DW_ATE
     | DW_ATE_decimal_float
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_ATE where showbPrec = genericShowbPrec
 
 dw_ate :: Word64 -> DW_ATE
 dw_ate 0x01 = DW_ATE_address

--- a/src/Data/Dwarf/CFA.hs
+++ b/src/Data/Dwarf/CFA.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Data.Dwarf.CFA where
 
-import           Control.Applicative (Applicative(..))
 import           Data.Binary.Get (getWord8, Get)
 import           Data.Bits (shiftR, (.&.))
 import qualified Data.ByteString as B

--- a/src/Data/Dwarf/CFA.hs
+++ b/src/Data/Dwarf/CFA.hs
@@ -9,8 +9,6 @@ import           Data.Dwarf.Utils
 import           Data.Int (Int64)
 import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 -- Section 7.22 - Call Frame
 data DW_CFA
@@ -42,7 +40,6 @@ data DW_CFA
     | DW_CFA_val_expression Word64 B.ByteString
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_CFA where showbPrec = genericShowbPrec
 
 getDW_CFA :: Reader -> Get DW_CFA
 getDW_CFA dr = do

--- a/src/Data/Dwarf/Form.hs
+++ b/src/Data/Dwarf/Form.hs
@@ -3,8 +3,6 @@ module Data.Dwarf.Form where
 
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import TextShow (TextShow(..))
-import TextShow.Generic (genericShowbPrec)
 
 data DW_FORM
     = DW_FORM_addr              -- ^ address
@@ -34,7 +32,6 @@ data DW_FORM
     | DW_FORM_ref_sig8            -- ^ (Dwarf 4)
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_FORM where showbPrec = genericShowbPrec
 
 dw_form :: Word64 -> DW_FORM
 dw_form 0x01 = DW_FORM_addr

--- a/src/Data/Dwarf/LNI.hs
+++ b/src/Data/Dwarf/LNI.hs
@@ -2,7 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Data.Dwarf.LNI where
 
-import           Control.Applicative (Applicative(..), (<$>))
 import           Control.Monad (replicateM)
 import           Data.Binary (Binary(..), Get)
 import           Data.Binary.Get (getWord8)
@@ -12,7 +11,6 @@ import           Data.Dwarf.Reader
 import           Data.Dwarf.Utils
 import           Data.Int (Int8, Int64)
 import           Data.Text (Text)
-import           Data.Traversable (traverse)
 import           Data.Word (Word8, Word64)
 import           GHC.Generics (Generic)
 import           TextShow (TextShow(..))

--- a/src/Data/Dwarf/LNI.hs
+++ b/src/Data/Dwarf/LNI.hs
@@ -13,8 +13,6 @@ import           Data.Int (Int8, Int64)
 import           Data.Text (Text)
 import           Data.Word (Word8, Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 -- Section 7.21 - Line Number Information
 data DW_LNI
@@ -36,7 +34,6 @@ data DW_LNI
     | DW_LNE_define_file Text Word64 Word64 Word64
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_LNI where showbPrec = genericShowbPrec
 
 getDW_LNI :: Reader -> Int64 -> Word8 -> Word8 -> Word64 -> Get DW_LNI
 getDW_LNI dr line_base line_range opcode_base minimum_instruction_length = getWord8 >>= getDW_LNI_
@@ -135,7 +132,6 @@ data DW_LNE = DW_LNE
     , lnmFiles         :: [(Text, Word64, Word64, Word64)]
     } deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_LNE where showbPrec = genericShowbPrec
 
 defaultLNE :: Bool -> [(Text, Word64, Word64, Word64)] -> DW_LNE
 defaultLNE is_stmt files = DW_LNE

--- a/src/Data/Dwarf/LNI.hs
+++ b/src/Data/Dwarf/LNI.hs
@@ -32,6 +32,7 @@ data DW_LNI
     | DW_LNE_end_sequence
     | DW_LNE_set_address Word64
     | DW_LNE_define_file Text Word64 Word64 Word64
+    | DW_LNE_set_discriminator Word64
     deriving (Eq, Ord, Read, Show, Generic)
 
 
@@ -44,6 +45,7 @@ getDW_LNI dr line_base line_range opcode_base minimum_instruction_length = getWo
                       getDW_LNE_ 0x01 = pure DW_LNE_end_sequence
                       getDW_LNE_ 0x02 = pure DW_LNE_set_address <*> drGetTargetAddress dr
                       getDW_LNE_ 0x03 = pure DW_LNE_define_file <*> getUTF8Str0 <*> getULEB128 <*> getULEB128 <*> getULEB128
+                      getDW_LNE_ 0x04 = pure DW_LNE_set_discriminator <*> getULEB128
                       getDW_LNE_ n | 0x80 <= n && n <= 0xff = fail $ "User DW_LNE data requires extension of parser for code " ++ show n
                       getDW_LNE_ n = fail $ "Unexpected DW_LNE code " ++ show n
           getDW_LNI_ 0x01 = pure DW_LNS_copy
@@ -107,6 +109,9 @@ stepLineMachine is_stmt mil lnm (DW_LNS_set_epilogue_begin : xs) =
 stepLineMachine is_stmt mil lnm (DW_LNS_set_isa isa : xs) =
     let new = lnm { lnmISA = isa }
     in stepLineMachine is_stmt mil new xs
+stepLineMachine is_stmt mil lnm (DW_LNE_set_discriminator d : xs) =
+    let new = lnm { lnmDiscriminator = d }
+    in stepLineMachine is_stmt mil new xs
 stepLineMachine is_stmt mil lnm (DW_LNE_end_sequence : xs) =
     let row = lnm { lnmEndSequence = True }
         new = defaultLNE is_stmt (lnmFiles lnm)
@@ -129,6 +134,7 @@ data DW_LNE = DW_LNE
     , lnmPrologueEnd   :: Bool
     , lnmEpilogueBegin :: Bool
     , lnmISA           :: Word64
+    , lnmDiscriminator :: Word64
     , lnmFiles         :: [(Text, Word64, Word64, Word64)]
     } deriving (Eq, Ord, Read, Show, Generic)
 
@@ -145,6 +151,7 @@ defaultLNE is_stmt files = DW_LNE
     , lnmPrologueEnd   = False
     , lnmEpilogueBegin = False
     , lnmISA           = 0
+    , lnmDiscriminator = 0
     , lnmFiles         = files
     }
 

--- a/src/Data/Dwarf/OP.hs
+++ b/src/Data/Dwarf/OP.hs
@@ -8,8 +8,6 @@ import           Data.Dwarf.Utils
 import           Data.Int (Int8, Int16, Int32, Int64)
 import           Data.Word (Word8, Word16, Word32, Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 data DW_OP
     = DW_OP_addr Word64
@@ -73,7 +71,6 @@ data DW_OP
     | DW_OP_bit_piece Word64 Word64
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_OP where showbPrec = genericShowbPrec
 
 -- | Parse a ByteString into a DWARF opcode. This will be needed for further decoding of DIE attributes.
 parseDW_OP :: Reader -> B.ByteString -> DW_OP

--- a/src/Data/Dwarf/OP.hs
+++ b/src/Data/Dwarf/OP.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Data.Dwarf.OP where
 
-import           Control.Applicative (Applicative(..), (<$>))
 import           Data.Binary.Get (getWord8, Get)
 import qualified Data.ByteString as B
 import           Data.Dwarf.Reader

--- a/src/Data/Dwarf/Reader.hs
+++ b/src/Data/Dwarf/Reader.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Data.Dwarf.Reader where
 
-import           Control.Applicative ((<$>), pure)
 import           Data.Binary.Get (getWord16be, getWord32be, getWord64be, getWord16le, getWord32le, getWord64le, Get)
 import qualified Data.Binary.Get as Get
 import           Data.Word (Word16, Word32, Word64)

--- a/src/Data/Dwarf/Reader.hs
+++ b/src/Data/Dwarf/Reader.hs
@@ -5,23 +5,18 @@ import           Data.Binary.Get (getWord16be, getWord32be, getWord64be, getWord
 import qualified Data.Binary.Get as Get
 import           Data.Word (Word16, Word32, Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 data Endianess = LittleEndian | BigEndian
   deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow Endianess where showbPrec = genericShowbPrec
 
 data Encoding = Encoding32 | Encoding64
   deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow Encoding where showbPrec = genericShowbPrec
 
 data TargetSize = TargetSize32 | TargetSize64
   deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow TargetSize where showbPrec = genericShowbPrec
 
 endianReader :: Endianess -> EndianReader
 endianReader LittleEndian = EndianReader LittleEndian getWord16le getWord32le getWord64le

--- a/src/Data/Dwarf/TAG.hs
+++ b/src/Data/Dwarf/TAG.hs
@@ -5,8 +5,6 @@ import Data.Binary.Get (Get)
 import Data.Dwarf.Utils
 import Data.Word (Word64)
 import GHC.Generics (Generic)
-import TextShow (TextShow(..))
-import TextShow.Generic (genericShowbPrec)
 
 data DW_TAG
     = DW_TAG_array_type
@@ -69,7 +67,6 @@ data DW_TAG
     | DW_TAG_user Word64 -- index into the user range of tags 0x4080 becomes 0
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_TAG where showbPrec = genericShowbPrec
 
 getDW_TAG :: Get DW_TAG
 getDW_TAG = getULEB128 >>= dw_tag

--- a/src/Data/Dwarf/TAG.hs
+++ b/src/Data/Dwarf/TAG.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Data.Dwarf.TAG where
 
-import Control.Applicative (pure)
 import Data.Binary.Get (Get)
 import Data.Dwarf.Utils
 import Data.Word (Word64)

--- a/src/Data/Dwarf/Types.hs
+++ b/src/Data/Dwarf/Types.hs
@@ -2,8 +2,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Data.Dwarf.Types where
 
-import           Data.Monoid ((<>))
-import qualified Data.Text as Text
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
 import           TextShow (TextShow(..))

--- a/src/Data/Dwarf/Types.hs
+++ b/src/Data/Dwarf/Types.hs
@@ -98,6 +98,7 @@ data DW_LANG
     | DW_LANG_ObjC_plus_plus
     | DW_LANG_UPC
     | DW_LANG_D
+    | DW_LANG_Haskell
     | DW_LANG_User Int -- 0x8000..0xFFFF
     deriving (Eq, Ord, Read, Show, Generic)
 
@@ -122,6 +123,7 @@ dw_lang 0x0010 = DW_LANG_ObjC
 dw_lang 0x0011 = DW_LANG_ObjC_plus_plus
 dw_lang 0x0012 = DW_LANG_UPC
 dw_lang 0x0013 = DW_LANG_D
+dw_lang 0x0018 = DW_LANG_Haskell
 dw_lang n
   | 0x8000 <= n && n <= 0xffff =
     DW_LANG_User $ fromIntegral n

--- a/src/Data/Dwarf/Types.hs
+++ b/src/Data/Dwarf/Types.hs
@@ -4,16 +4,10 @@ module Data.Dwarf.Types where
 
 import           Data.Word (Word64)
 import           GHC.Generics (Generic)
-import           TextShow (TextShow(..))
-import           TextShow.Generic (genericShowbPrec)
 
 newtype DieID = DieID Word64
-  deriving (Eq, Ord)
+  deriving (Eq, Ord, Show)
 
-instance TextShow DieID where
-  showb (DieID x) = "DIE@" <> showb x
-
-instance Show DieID where show = Text.unpack . showt
 
 data DW_DS
     = DW_DS_unsigned
@@ -23,7 +17,6 @@ data DW_DS
     | DW_DS_trailing_separate
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_DS where showbPrec = genericShowbPrec
 
 dw_ds :: Word64 -> DW_DS
 dw_ds 0x01 = DW_DS_unsigned
@@ -39,7 +32,6 @@ data DW_END
     | DW_END_little
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_END where showbPrec = genericShowbPrec
 
 dw_end :: Word64 -> DW_END
 dw_end 0x00 = DW_END_default
@@ -53,7 +45,6 @@ data DW_ACCESS
     | DW_ACCESS_private
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_ACCESS where showbPrec = genericShowbPrec
 
 dw_access :: Word64 -> DW_ACCESS
 dw_access 0x01 = DW_ACCESS_public
@@ -67,7 +58,6 @@ data DW_VIS
     | DW_VIS_qualified
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_VIS where showbPrec = genericShowbPrec
 
 dw_vis :: Word64 -> DW_VIS
 dw_vis 0x01 = DW_VIS_local
@@ -81,7 +71,6 @@ data DW_VIRTUALITY
     | DW_VIRTUALITY_return_virtual
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_VIRTUALITY where showbPrec = genericShowbPrec
 
 dw_virtuality :: Word64 -> DW_VIRTUALITY
 dw_virtuality 0x00 = DW_VIRTUALITY_none
@@ -112,7 +101,6 @@ data DW_LANG
     | DW_LANG_User Int -- 0x8000..0xFFFF
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_LANG where showbPrec = genericShowbPrec
 
 dw_lang :: Word64 -> DW_LANG
 dw_lang 0x0001 = DW_LANG_C89
@@ -147,7 +135,6 @@ data DW_ID
     | DW_ID_case_insensitive
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_ID where showbPrec = genericShowbPrec
 
 dw_id :: Word64 -> DW_ID
 dw_id 0x00 = DW_ID_case_sensitive
@@ -162,7 +149,6 @@ data DW_CC
     | DW_CC_nocall
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_CC where showbPrec = genericShowbPrec
 
 dw_cc :: Word64 -> DW_CC
 dw_cc 0x01 = DW_CC_normal
@@ -177,7 +163,6 @@ data DW_INL
     | DW_INL_declared_inlined
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_INL where showbPrec = genericShowbPrec
 
 dw_inl :: Word64 -> DW_INL
 dw_inl 0x00 = DW_INL_not_inlined
@@ -191,7 +176,6 @@ data DW_ORD
     | DW_ORD_col_major
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_ORD where showbPrec = genericShowbPrec
 
 dw_ord :: Word64 -> DW_ORD
 dw_ord 0x00 = DW_ORD_row_major
@@ -203,7 +187,6 @@ data DW_DSC
     | DW_DSC_range
     deriving (Eq, Ord, Read, Show, Generic)
 
-instance TextShow DW_DSC where showbPrec = genericShowbPrec
 
 dw_dsc :: Word64 -> DW_DSC
 dw_dsc 0x00 = DW_DSC_label

--- a/src/Data/Dwarf/Utils.hs
+++ b/src/Data/Dwarf/Utils.hs
@@ -1,6 +1,5 @@
 module Data.Dwarf.Utils where
 
-import           Control.Applicative (Applicative(..), (<$>), (*>))
 import           Data.Binary.Get (getByteString, getWord8, Get, runGet)
 import qualified Data.Binary.Get as Get
 import           Data.Bits ((.|.), shiftL, clearBit, testBit)
@@ -70,11 +69,11 @@ getSLEB128 =
 -- Decode an unsigned little-endian base 128 encoded integer.
 getULEB128 :: Get Word64
 getULEB128 =
-    let go acc shift = do
+    let go acc shift' = do
         byte <- fromIntegral <$> getWord8 :: Get Word64
-        let temp = acc .|. (clearBit byte 7 `shiftL` shift)
+        let temp = acc .|. (clearBit byte 7 `shiftL` shift')
         if testBit byte 7 then
-            go temp (shift + 7)
+            go temp (shift' + 7)
          else
             pure temp
     in go 0 0

--- a/src/Data/Dwarf/Utils.hs
+++ b/src/Data/Dwarf/Utils.hs
@@ -2,14 +2,14 @@ module Data.Dwarf.Utils where
 
 import           Data.Binary.Get (getByteString, getWord8, Get, runGet)
 import qualified Data.Binary.Get as Get
-import           Data.Bits ((.|.), shiftL, clearBit, testBit)
+import           Data.Bits
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as L
-import           Data.Int (Int64)
+import           Data.Int (Int64, Int8)
 import           Data.Text (Text)
 import qualified Data.Text as Text
 import qualified Data.Text.Encoding as Encoding
-import           Data.Word (Word64)
+import           Data.Word (Word64, Word8)
 
 whileJust :: (Applicative m, Monad m) => m (Maybe a) -> m [a]
 whileJust act = go
@@ -51,20 +51,18 @@ getNonEmptyUTF8Str0 = do
   str <- getUTF8Str0
   pure $ if Text.null str then Nothing else Just str
 
--- Decode a signed little-endian base 128 encoded integer.
+-- | Get a signed int in Little Endian Base 128
+-- This is taken from the haskus package
 getSLEB128 :: Get Int64
-getSLEB128 =
-    let go acc shift = do
-        byte <- fromIntegral <$> getWord8 :: Get Word64
-        let temp = acc .|. (clearBit byte 7 `shiftL` shift)
-        if testBit byte 7 then
-            go temp (shift + 7)
-         else
-            if shift < 32  && testBit byte 6 then
-                pure $ fromIntegral $ temp .|. (maxBound `shiftL` shift)
-             else
-                pure $ fromIntegral temp
-    in go 0 0
+getSLEB128 = do
+   let toInt8 :: Word8 -> Int8
+       toInt8 = fromIntegral
+   a <- getWord8
+   if not (testBit a 7)
+      then return . fromIntegral . toInt8 $ (a .&. 0x7f) .|. ((a .&. 0x40) `shiftL` 1)
+      else do
+         b <- getSLEB128
+         return $ (b `shiftL` 7) .|. (fromIntegral (a .&. 0x7f))
 
 -- Decode an unsigned little-endian base 128 encoded integer.
 getULEB128 :: Get Word64


### PR DESCRIPTION
This series of patches makes `dwarf` work with `ghc-debug`, a debugger for Haskell's RTS implemented in Haskell. I needed to read the DWARF information to display line number information to users. 

1. Remove `text-show` and `lens` dependencies as they are heavy and unused. It made compiling the library with HEAD a lot more difficult.
2. Fix a bug decoding signed LEB128 values (9bc1726)
3. Add support for `DW_Lang = Haskell` and `DW_LNE_set_discriminator`
4. Add support for parsing the `.debug_line` sections

There will also be a corresponding PR to dwarfadt. 